### PR TITLE
Is defined fast undefined value return false

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ For example:
                 UnitTests.UserTypeTest.Men => true,
                 UnitTests.UserTypeTest.Women => true,
                 UnitTests.UserTypeTest.None => true,
-                _ => throw new ArgumentOutOfRangeException(nameof(states), states, null)
+                _ => false
             };
         }
         public static bool IsDefinedFast(string states)
@@ -67,7 +67,7 @@ For example:
                 nameof(UnitTests.UserTypeTest.Men) => true,
                 nameof(UnitTests.UserTypeTest.Women) => true,
                 nameof(UnitTests.UserTypeTest.None) => true,
-                _ => throw new ArgumentOutOfRangeException(nameof(states), states, null)
+                _ => false
             };
         }
         public static string ToDisplayFast(this UnitTests.UserTypeTest states)

--- a/Supernova.Enum.Generators/EnumSourceGenerator.cs
+++ b/Supernova.Enum.Generators/EnumSourceGenerator.cs
@@ -168,7 +168,7 @@ namespace {SourceGeneratorHelper.NameSpace}
         foreach (var member in e.Members.Select(x => x.Identifier.ValueText))
             sourceBuilder.AppendLine($@"                nameof({symbolName}.{member}) => true,");
         sourceBuilder.Append(
-            @"                _ => throw new ArgumentOutOfRangeException(nameof(states), states, null)
+            @"                _ => false
             };
         }");
     }
@@ -184,7 +184,7 @@ namespace {SourceGeneratorHelper.NameSpace}
         foreach (var member in e.Members.Select(x => x.Identifier.ValueText))
             sourceBuilder.AppendLine($@"                {symbolName}.{member} => true,");
         sourceBuilder.Append(
-            @"                _ => throw new ArgumentOutOfRangeException(nameof(states), states, null)
+            @"                _ => false
             };
         }");
     }

--- a/test/UnitTests/EnumGeneratorTest.cs
+++ b/test/UnitTests/EnumGeneratorTest.cs
@@ -45,6 +45,14 @@ public class EnumGeneratorTest
     }
 
     [TestMethod]
+    public void TestEnumToString_Undefined()
+    {
+        var action = () => GetUndefinedEnumValue().ToStringFast();
+
+        action.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [TestMethod]
     public void TestEnumToDisplay()
     {
         var menString = UserTypeTest.Men.ToDisplayFast();
@@ -58,6 +66,14 @@ public class EnumGeneratorTest
         var menString = UserTypeTest.None.ToDisplayFast();
 
         Assert.AreEqual("None", menString);
+    }
+
+    [TestMethod]
+    public void TestEnumToDisplay_Undefined()
+    {
+        var action = () => GetUndefinedEnumValue().ToDisplayFast();
+
+        action.Should().Throw<ArgumentOutOfRangeException>();
     }
 
     [TestMethod]
@@ -91,4 +107,6 @@ public class EnumGeneratorTest
 
         Assert.AreEqual(Enum.GetValues<UserTypeTest>().Length, length);
     }
+
+    private UserTypeTest GetUndefinedEnumValue() => (UserTypeTest)(-1);
 }

--- a/test/UnitTests/EnumGeneratorTest.cs
+++ b/test/UnitTests/EnumGeneratorTest.cs
@@ -29,6 +29,14 @@ public class EnumGeneratorTest
     }
 
     [TestMethod]
+    public void TestEnumDefined_Undefined()
+    {
+        var defined = UserTypeTestEnumExtensions.IsDefinedFast("DoesNotExist");
+
+        Assert.IsFalse(defined);
+    }
+
+    [TestMethod]
     public void TestEnumToString()
     {
         var menString = UserTypeTest.Men.ToStringFast();


### PR DESCRIPTION
This is a breaking change to amend the behaviour of `IsDefinedFast` to not throw an `ArgumentOutOfRangeException` exception when the value does not exist, as requested in issue #14.

It might be worth adding a separate method along the lines of `AssertIsDefinedFast` in case anyone is dependent on the current behaviour.