### PR TITLE
BREAKING CHANGE: Changed the namespace of the generated extension met…

### DIFF
--- a/Supernova.Enum.Generators/EnumSourceGenerator.cs
+++ b/Supernova.Enum.Generators/EnumSourceGenerator.cs
@@ -5,6 +5,7 @@ using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
+using Supernova.Enum.Generators.Extensions;
 
 namespace Supernova.Enum.Generators;
 
@@ -24,7 +25,7 @@ public class EnumSourceGenerator : ISourceGenerator
         //        }
         //#endif
         context.AddSource($"{SourceGeneratorHelper.AttributeName}Attribute.g.cs", SourceText.From($@"using System;
-namespace {SourceGeneratorHelper.NameSpace}
+namespace Supernova.Enum.Generators
 {{
     [AttributeUsage(AttributeTargets.Enum)]
     public sealed class {SourceGeneratorHelper.AttributeName}Attribute : Attribute
@@ -104,7 +105,8 @@ namespace {SourceGeneratorHelper.NameSpace}
             var sourceBuilder = new StringBuilder($@"using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-namespace {SourceGeneratorHelper.NameSpace}
+
+namespace {symbol.ContainingNamespace.FullName()}
 {{
     {symbol.DeclaredAccessibility.ToString("G").ToLower()} static class {symbol.Name}EnumExtensions
     {{");

--- a/Supernova.Enum.Generators/Extensions/NamespaceSymbolExtensions.cs
+++ b/Supernova.Enum.Generators/Extensions/NamespaceSymbolExtensions.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using Microsoft.CodeAnalysis;
+
+namespace Supernova.Enum.Generators.Extensions;
+
+/// <summary>
+/// Provides extension methods for <see cref="INamespaceSymbol"/> objects.
+/// </summary>
+public static class NamespaceSymbolExtensions
+{
+    /// <summary>
+    /// Gets the full name of the namespace, including parent namespaces.
+    /// </summary>
+    /// <param name="namespaceSymbol">The namespace symbol.</param>
+    /// <param name="fullName">Optional. The initial full name to start with.</param>
+    /// <returns>The full name of the namespace.</returns>
+    public static string FullName(this INamespaceSymbol namespaceSymbol, string fullName = null)
+    {
+        fullName ??= string.Empty;
+
+        if (namespaceSymbol == null)
+        {
+            return fullName;
+        }
+        
+        if (namespaceSymbol.ContainingNamespace != null)
+        {
+            fullName = namespaceSymbol.ContainingNamespace.FullName(fullName);
+        }
+
+        if (!fullName.Equals(string.Empty, StringComparison.OrdinalIgnoreCase))
+        {
+            fullName += ".";
+        }
+
+        fullName += namespaceSymbol.Name;
+
+        return fullName;
+    }
+}

--- a/test/Console.Test.Benchmark/Program.cs
+++ b/test/Console.Test.Benchmark/Program.cs
@@ -8,13 +8,13 @@ using BenchmarkDotNet.Exporters;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Order;
 using BenchmarkDotNet.Running;
-using EnumFastToStringGenerated;
 using Perfolizer.Horology;
 using System;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
+using Supernova.Enum.Generators;
 
 namespace Console.Test.Benchmark;
 

--- a/test/UnitTests/EnumGeneratorTest.cs
+++ b/test/UnitTests/EnumGeneratorTest.cs
@@ -1,9 +1,9 @@
-﻿using EnumFastToStringGenerated;
-using FluentAssertions;
+﻿using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using Supernova.Enum.Generators;
 
 namespace UnitTests;
 

--- a/test/UnitTests/InternalEnumGeneratorTest.cs
+++ b/test/UnitTests/InternalEnumGeneratorTest.cs
@@ -1,9 +1,9 @@
-﻿using EnumFastToStringGenerated;
-using FluentAssertions;
+﻿using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using Supernova.Enum.Generators;
 
 namespace UnitTests;
 


### PR DESCRIPTION
Changed the namespace of the generated extension methods to the same as the enum. Moved the generated attribute namespace to the generator namespace.

Why?

To keep the namespaces as clear as possible, the namespace of the extensions has been changed to that of the enum. The attribute that is also generated is now in the namespace of the generator, which makes it possible to search for this namespace with the usual search engines.

The previous namespace was completely unsuitable for this.