### PR TITLE
Added ToShortNames and DisplayShortNames dictionary

### DIFF
--- a/Supernova.Enum.Generators/EnumSourceGenerator.cs
+++ b/Supernova.Enum.Generators/EnumSourceGenerator.cs
@@ -105,7 +105,7 @@ namespace {SourceGeneratorHelper.NameSpace}
                         {
                             enumDescriptions.Add(member.Name, description);
                         }
-                        if (namedArgument.Key.Equals("ShortName", StringComparison.OrdinalIgnoreCase) &&
+                        if (namedArgument.Key.Equals(ShortNameKey, StringComparison.OrdinalIgnoreCase) &&
                          namedArgument.Value.Value?.ToString() is { } shortName)
                         {
                             enumShortNames.Add(member.Name, shortName);

--- a/Supernova.Enum.Generators/EnumSourceGenerator.cs
+++ b/Supernova.Enum.Generators/EnumSourceGenerator.cs
@@ -80,6 +80,8 @@ namespace {SourceGeneratorHelper.NameSpace}
             /**********************/
             var enumDisplayNames = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             var enumDescriptions = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            var enumShortNames = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
             foreach (var member in enumSymbol.GetMembers())
             {
                 if (member is not IFieldSymbol field
@@ -103,7 +105,11 @@ namespace {SourceGeneratorHelper.NameSpace}
                         {
                             enumDescriptions.Add(member.Name, description);
                         }
-
+                        if (namedArgument.Key.Equals("ShortName", StringComparison.OrdinalIgnoreCase) &&
+                         namedArgument.Value.Value?.ToString() is { } shortName)
+                        {
+                            enumShortNames.Add(member.Name, shortName);
+                        }
                     }
                 }
             }
@@ -126,6 +132,9 @@ namespace {SourceGeneratorHelper.NameSpace}
             //DisplayNames Dictionary
             DisplayNamesDictionary(sourceBuilder, symbol, e, enumDisplayNames);
 
+            //DisplayShortNames Dictionary
+            DisplayShortNamesDictionary(sourceBuilder, symbol, e, enumShortNames);
+
             //DisplayDescriptions Dictionary
             DisplayDescriptionsDictionary(sourceBuilder, symbol, e, enumDescriptions);
 
@@ -143,6 +152,9 @@ namespace {SourceGeneratorHelper.NameSpace}
 
             //ToDisplay string
             ToDescription(sourceBuilder, symbol, e, enumDescriptions);
+
+            //ToShortName
+            ToShortName(sourceBuilder, symbol, e, enumShortNames);
 
             //GetValues
             GetValuesFast(sourceBuilder, symbol, e);
@@ -179,6 +191,7 @@ namespace {SourceGeneratorHelper.NameSpace}
         /// <returns>The display string of the <see cref=""global::{symbol.FullName()}"" /> value.</returns>
         public static string {SourceGeneratorHelper.ExtensionMethodNameToDisplay}(this {symbol.FullName()} states, string defaultValue = null)
         {{
+
             return states switch
             {{
 ");
@@ -190,6 +203,37 @@ namespace {SourceGeneratorHelper.NameSpace}
                 : key;
             sourceBuilder.AppendLine(
                 $@"                {symbol}.{member.Identifier.ValueText} => ""{enumDisplayName ?? key}"",");
+        }
+
+        sourceBuilder.Append(
+            @"                _ => defaultValue ?? throw new ArgumentOutOfRangeException(nameof(states), states, null)
+            };
+        }
+");
+    }
+
+    private static void ToShortName(StringBuilder sourceBuilder, ISymbol symbol, EnumDeclarationSyntax e, Dictionary<string, string> enumShortNames)
+    {
+        sourceBuilder.Append($@"
+        /// <summary>
+        /// Converts the <see cref=""global::{symbol.FullName()}"" /> enumeration value to its short name string.
+        /// </summary>
+        /// <param name=""states"">The <see cref=""global::{symbol.FullName()}"" /> enumeration value.</param>
+        /// <param name=""defaultValue"">The default value to return if the enumeration value is not recognized.</param>
+        /// <returns>The short name string of the <see cref=""global::{symbol.FullName()}"" /> value.</returns>
+        public static string {SourceGeneratorHelper.ExtensionMethodNameToShortName}(this {symbol.FullName()} states, string defaultValue = null)
+        {{
+            return states switch
+            {{
+");
+        foreach (var member in e.Members)
+        {
+            var key = member.Identifier.ValueText;
+            var enumShortName = enumShortNames.TryGetValue(key, out var found)
+                ? found
+                : key;
+            sourceBuilder.AppendLine(
+                $@"                {symbol}.{member.Identifier.ValueText} => ""{enumShortName ?? key}"",");
         }
 
         sourceBuilder.Append(
@@ -341,6 +385,31 @@ namespace {SourceGeneratorHelper.NameSpace}
                 : key;
             sourceBuilder.AppendLine(
                 $@"                {{{symbol.FullName()}.{member.Identifier.ValueText}, ""{enumDescription ?? key}""}},");
+        }
+        sourceBuilder.Append(
+            @"
+        }.ToImmutableDictionary();
+");
+    }
+
+    private static void DisplayShortNamesDictionary(StringBuilder sourceBuilder, ISymbol symbol, EnumDeclarationSyntax e,
+        Dictionary<string, string> enumShortNames)
+    {
+        sourceBuilder.Append($@"
+        /// <summary>
+        /// Provides a dictionary that maps <see cref=""global::{symbol.FullName()}"" /> values to their corresponding short names.
+        /// </summary>
+        public static readonly ImmutableDictionary<{symbol.FullName()}, string> {SourceGeneratorHelper.PropertyDisplayShortNamesDictionary} = new Dictionary<{symbol.FullName()}, string>
+        {{
+");
+        foreach (var member in e.Members)
+        {
+            var key = member.Identifier.ValueText;
+            var enumShortName = enumShortNames.TryGetValue(key, out var found)
+                ? found
+                : key;
+            sourceBuilder.AppendLine(
+                $@"                {{{symbol}.{member.Identifier.ValueText}, ""{enumShortName ?? key}""}},");
         }
         sourceBuilder.Append(
             @"

--- a/Supernova.Enum.Generators/EnumSourceGenerator.cs
+++ b/Supernova.Enum.Generators/EnumSourceGenerator.cs
@@ -191,7 +191,6 @@ namespace {SourceGeneratorHelper.NameSpace}
         /// <returns>The display string of the <see cref=""global::{symbol.FullName()}"" /> value.</returns>
         public static string {SourceGeneratorHelper.ExtensionMethodNameToDisplay}(this {symbol.FullName()} states, string defaultValue = null)
         {{
-
             return states switch
             {{
 ");
@@ -233,7 +232,7 @@ namespace {SourceGeneratorHelper.NameSpace}
                 ? found
                 : key;
             sourceBuilder.AppendLine(
-                $@"                {symbol}.{member.Identifier.ValueText} => ""{enumShortName ?? key}"",");
+                $@"                {symbol}.{member.Identifier.ValueText} => ""{enumShortName}"",");
         }
 
         sourceBuilder.Append(

--- a/Supernova.Enum.Generators/EnumSourceGenerator.cs
+++ b/Supernova.Enum.Generators/EnumSourceGenerator.cs
@@ -408,7 +408,7 @@ namespace {SourceGeneratorHelper.NameSpace}
                 ? found
                 : key;
             sourceBuilder.AppendLine(
-                $@"                {{{symbol}.{member.Identifier.ValueText}, ""{enumShortName ?? key}""}},");
+                $@"                {{{symbol}.{member.Identifier.ValueText}, ""{enumShortName}""}},");
         }
         sourceBuilder.Append(
             @"

--- a/Supernova.Enum.Generators/EnumSourceGenerator.cs
+++ b/Supernova.Enum.Generators/EnumSourceGenerator.cs
@@ -105,7 +105,7 @@ namespace {SourceGeneratorHelper.NameSpace}
                         {
                             enumDescriptions.Add(member.Name, description);
                         }
-                        if (namedArgument.Key.Equals(ShortNameKey, StringComparison.OrdinalIgnoreCase) &&
+                        if (namedArgument.Key.Equals("ShortName", StringComparison.OrdinalIgnoreCase) &&
                          namedArgument.Value.Value?.ToString() is { } shortName)
                         {
                             enumShortNames.Add(member.Name, shortName);

--- a/Supernova.Enum.Generators/SourceGeneratorHelper.cs
+++ b/Supernova.Enum.Generators/SourceGeneratorHelper.cs
@@ -8,11 +8,13 @@ public static class SourceGeneratorHelper
     public const string ExtensionMethodNameIsDefined = "IsDefinedFast";
     public const string ExtensionMethodNameToDisplay = "ToDisplayFast";
     public const string ExtensionMethodNameToDescription = "ToDescriptionFast";
+    public const string ExtensionMethodNameToShortName = "ToShortNameFast";
     public const string ExtensionMethodNameGetValues = "GetValuesFast";
     public const string ExtensionMethodNameGetNames = "GetNamesFast";
     public const string ExtensionMethodNameGetLength = "GetLengthFast";
     public const string ExtensionMethodNameTryParse = "TryParseFast";
     public const string PropertyDisplayNamesDictionary = "DisplayNamesDictionary";
+    public const string PropertyDisplayShortNamesDictionary = "DisplayShortNamesDictionary";
     public const string PropertyDisplayDescriptionsDictionary = "DisplayDescriptionsDictionary";
 
 }

--- a/test/Console.Test.Benchmark/Program.cs
+++ b/test/Console.Test.Benchmark/Program.cs
@@ -194,7 +194,7 @@ public static class Ext
             .GetCustomAttributes<DisplayAttribute>(false).FirstOrDefault();
         if (attribute == null)
             return value.ToString();
-        var propValue = attribute.GetType().GetProperty("ShortName")?.GetValue(attribute, null);
+        var propValue = attribute.GetType().GetProperty(ShortNameProperty)?.GetValue(attribute, null);
         return propValue?.ToString();
     }
 

--- a/test/Console.Test.Benchmark/Program.cs
+++ b/test/Console.Test.Benchmark/Program.cs
@@ -21,9 +21,9 @@ namespace Console.Test.Benchmark;
 [EnumGenerator]
 public enum UserType
 {
-    [Display(Name = "مرد", Description = "men")] Men,
+    [Display(Name = "مرد", Description = "men", ShortName = "M")] Men,
 
-    [Display(Name = "زن", Description = "women")] Women,
+    [Display(Name = "زن", Description = "women", ShortName = "W")] Women,
 
     //[Display(Name = "نامشخص")]
     None
@@ -95,6 +95,18 @@ public class EnumBenchmark
     public string FastToDisplay()
     {
         return UserType.Men.ToDisplayFast();
+    }
+
+    [Benchmark]
+    public string NativeToShortName()
+    {
+        return UserType.Men.ToShortNameNative();
+    }
+
+    [Benchmark]
+    public string FastToShortName()
+    {
+        return UserType.Men.ToShortNameFast();
     }
 
     [Benchmark]
@@ -173,6 +185,19 @@ public static class Ext
 
         return propValue?.ToString();
     }
+
+    public static string ToShortNameNative(this Enum value)
+    {
+        if (value is null)
+            throw new ArgumentNullException(nameof(value));
+        var attribute = value.GetType().GetField(value.ToString())?
+            .GetCustomAttributes<DisplayAttribute>(false).FirstOrDefault();
+        if (attribute == null)
+            return value.ToString();
+        var propValue = attribute.GetType().GetProperty("ShortName")?.GetValue(attribute, null);
+        return propValue?.ToString();
+    }
+
     public static string ToDescriptionNative(this Enum value)
     {
         if (value is null)

--- a/test/UnitTests/EnumGeneratorTest.cs
+++ b/test/UnitTests/EnumGeneratorTest.cs
@@ -10,9 +10,9 @@ namespace UnitTests;
 [EnumGenerator]
 public enum UserTypeTest
 {
-    [Display(Name = "مرد", Description = "Descمرد")] Men = 3,
+    [Display(Name = "مرد", Description = "Descمرد", ShortName = "M")] Men = 3,
 
-    [Display(Name = "زن", Description = "Descزن")] Women = 4,
+    [Display(Name = "زن", Description = "Descزن", ShortName = "W")] Women = 4,
 
     //[Display(Name = "نامشخص")]
     None
@@ -118,6 +118,32 @@ public class EnumGeneratorTest
     }
 
     [TestMethod]
+    public void TestEnumToShortName()
+    {
+        var menShortName = UserTypeTest.Men.ToShortNameFast();
+        var womenShortName = UserTypeTest.Women.ToShortNameFast();
+        var noneShortName = UserTypeTest.None.ToShortNameFast();
+
+        menShortName.Should().Be("M");
+        womenShortName.Should().Be("W");
+        noneShortName.Should().Be("None");
+    }
+
+    [TestMethod]
+    public void TestEnumToShortName_Undefined()
+    {
+        var action = () => GetUndefinedEnumValue().ToShortNameFast();
+        action.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [TestMethod]
+    public void TestEnumToShortName_Undefined_DefaultValue()
+    {
+        var value = GetUndefinedEnumValue().ToShortNameFast("DefaultValue");
+        value.Should().Be("DefaultValue");
+    }
+
+    [TestMethod]
     public void TestEnumGetNames()
     {
         var names = UserTypeTestEnumExtensions.GetNamesFast();
@@ -139,6 +165,20 @@ public class EnumGeneratorTest
             .And.ContainInOrder(
                 new KeyValuePair<UserTypeTest, string>(UserTypeTest.Men, "مرد"),
                 new KeyValuePair<UserTypeTest, string>(UserTypeTest.Women, "زن"),
+                new KeyValuePair<UserTypeTest, string>(UserTypeTest.None, "None")
+            );
+    }
+
+    [TestMethod]
+    public void TestEnumDisplayShortNamesDictionary()
+    {
+        var names = UserTypeTestEnumExtensions.DisplayShortNamesDictionary;
+        Assert.IsNotNull(names);
+        names.Should().NotBeEmpty()
+            .And.HaveCount(3)
+            .And.ContainInOrder(
+                new KeyValuePair<UserTypeTest, string>(UserTypeTest.Men, "M"),
+                new KeyValuePair<UserTypeTest, string>(UserTypeTest.Women, "W"),
                 new KeyValuePair<UserTypeTest, string>(UserTypeTest.None, "None")
             );
     }

--- a/test/UnitTests/InternalEnumGeneratorTest.cs
+++ b/test/UnitTests/InternalEnumGeneratorTest.cs
@@ -10,9 +10,9 @@ namespace UnitTests;
 [EnumGenerator]
 internal enum InternalUserTypeTest
 {
-    [Display(Name = "مرد", Description = "Descمرد")] Men = 3,
+    [Display(Name = "مرد", Description = "Descمرد", ShortName = "M")] Men = 3,
 
-    [Display(Name = "زن", Description = "Descزن")] Women = 4,
+    [Display(Name = "زن", Description = "Descزن", ShortName = "W")] Women = 4,
 
     //[Display(Name = "نامشخص")]
     None
@@ -118,6 +118,32 @@ public class InternalEnumGeneratorTest
     }
 
     [TestMethod]
+    public void TestEnumToShortName()
+    {
+        var menShortName = InternalUserTypeTest.Men.ToShortNameFast();
+        var womenShortName = InternalUserTypeTest.Women.ToShortNameFast();
+        var noneShortName = InternalUserTypeTest.None.ToShortNameFast();
+
+        menShortName.Should().Be("M");
+        womenShortName.Should().Be("W");
+        noneShortName.Should().Be("None");
+    }
+
+    [TestMethod]
+    public void TestEnumToShortName_Undefined()
+    {
+        var action = () => GetUndefinedEnumValue().ToShortNameFast();
+        action.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [TestMethod]
+    public void TestEnumToShortName_Undefined_DefaultValue()
+    {
+        var value = GetUndefinedEnumValue().ToShortNameFast("DefaultValue");
+        value.Should().Be("DefaultValue");
+    }
+
+    [TestMethod]
     public void TestEnumGetNames()
     {
         var names = InternalUserTypeTestEnumExtensions.GetNamesFast();
@@ -139,6 +165,20 @@ public class InternalEnumGeneratorTest
             .And.ContainInOrder(
                 new KeyValuePair<InternalUserTypeTest, string>(InternalUserTypeTest.Men, "مرد"),
                 new KeyValuePair<InternalUserTypeTest, string>(InternalUserTypeTest.Women, "زن"),
+                new KeyValuePair<InternalUserTypeTest, string>(InternalUserTypeTest.None, "None")
+            );
+    }
+
+    [TestMethod]
+    public void TestEnumDisplayShortNamesDictionary()
+    {
+        var names = InternalUserTypeTestEnumExtensions.DisplayShortNamesDictionary;
+        Assert.IsNotNull(names);
+        names.Should().NotBeEmpty()
+            .And.HaveCount(3)
+            .And.ContainInOrder(
+                new KeyValuePair<InternalUserTypeTest, string>(InternalUserTypeTest.Men, "M"),
+                new KeyValuePair<InternalUserTypeTest, string>(InternalUserTypeTest.Women, "W"),
                 new KeyValuePair<InternalUserTypeTest, string>(InternalUserTypeTest.None, "None")
             );
     }


### PR DESCRIPTION
This pull request introduces support for handling "short names" for enum values in the `Supernova.Enum.Generators` project. The changes include updates to the source generator to process a new `ShortName` attribute, generate corresponding extension methods and dictionaries, and add comprehensive tests to validate the functionality.

### Linked issues
resolves #138


### Enhancements to Enum Source Generator:

- Added a new dictionary `enumShortNames` to store short names for enum members and updated the source generator to populate it when the `ShortName` attribute is provided. (`Supernova.Enum.Generators/EnumSourceGenerator.cs`: [[1]](diffhunk://#diff-06a77d59d8c1b7c024f04618a92b546b2d917204f0d47360cefcda38f73cb4acR83-R84) [[2]](diffhunk://#diff-06a77d59d8c1b7c024f04618a92b546b2d917204f0d47360cefcda38f73cb4acL106-R112)
- Introduced the `ToShortName` method to generate extension methods for converting enum values to their short names. (`Supernova.Enum.Generators/EnumSourceGenerator.cs`: [[1]](diffhunk://#diff-06a77d59d8c1b7c024f04618a92b546b2d917204f0d47360cefcda38f73cb4acR156-R158) [[2]](diffhunk://#diff-06a77d59d8c1b7c024f04618a92b546b2d917204f0d47360cefcda38f73cb4acR215-R245)
- Added the `DisplayShortNamesDictionary` method to generate a dictionary mapping enum values to their short names. (`Supernova.Enum.Generators/EnumSourceGenerator.cs`: [Supernova.Enum.Generators/EnumSourceGenerator.csR395-R419](diffhunk://#diff-06a77d59d8c1b7c024f04618a92b546b2d917204f0d47360cefcda38f73cb4acR395-R419))

### Updates to Source Generator Helper:

- Added constants for the new `ToShortNameFast` extension method and `DisplayShortNamesDictionary` property. (`Supernova.Enum.Generators/SourceGeneratorHelper.cs`: [Supernova.Enum.Generators/SourceGeneratorHelper.csR11-R17](diffhunk://#diff-1c65d748c0a693593f29b361ef8aa1996fa644a61ec9d7a226d7b93576fa5b4bR11-R17))

### Test Enhancements:

- Updated test enums (`UserType`, `UserTypeTest`, and `InternalUserTypeTest`) to include the `ShortName` attribute for enum members. (`test/Console.Test.Benchmark/Program.cs`: [[1]](diffhunk://#diff-1848bf5a986599df2172b570122f828953db98b3dae75b8497464ef41f288077L24-R26) `test/UnitTests/EnumGeneratorTest.cs`: [[2]](diffhunk://#diff-95eedef79676c9352a1d2fddaa23dc725967910e27430dff16322fc849981dbbL13-R15) `test/UnitTests/InternalEnumGeneratorTest.cs`: [[3]](diffhunk://#diff-68038fe777acb8e0f4670f616d0c24e519a692dc2e53daea5cd24da827eed4adL13-R15)
- Added unit tests for `ToShortNameFast` extension method, including cases for undefined values and default values. (`test/UnitTests/EnumGeneratorTest.cs`: [[1]](diffhunk://#diff-95eedef79676c9352a1d2fddaa23dc725967910e27430dff16322fc849981dbbR120-R145) [[2]](diffhunk://#diff-95eedef79676c9352a1d2fddaa23dc725967910e27430dff16322fc849981dbbR172-R185); `test/UnitTests/InternalEnumGeneratorTest.cs`: [[3]](diffhunk://#diff-68038fe777acb8e0f4670f616d0c24e519a692dc2e53daea5cd24da827eed4adR120-R145) [[4]](diffhunk://#diff-68038fe777acb8e0f4670f616d0c24e519a692dc2e53daea5cd24da827eed4adR172-R185)
- Introduced benchmarks for the `ToShortNameFast` and `ToShortNameNative` methods to measure performance. (`test/Console.Test.Benchmark/Program.cs`: [[1]](diffhunk://#diff-1848bf5a986599df2172b570122f828953db98b3dae75b8497464ef41f288077R100-R111) [[2]](diffhunk://#diff-1848bf5a986599df2172b570122f828953db98b3dae75b8497464ef41f288077R188-R200)